### PR TITLE
back-channel logout poc for simple-rp-simulator

### DIFF
--- a/simple-rp-simulator/.env.example
+++ b/simple-rp-simulator/.env.example
@@ -1,0 +1,7 @@
+IBM_VERIFY_TENANT_URL=https://xxxxxxxxx.xxx
+IBM_VERIFY_RP_CLIENT_ID=xxxxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxx
+IBM_VERIFY_RP_CLIENT_SECRET=xxxxxxxxxx
+REDIRECT_URI=https://xxxxxxxxx.xxx/xxxx
+RESPONSE_TYPE=code
+SCOPE=openid
+POST_LOGOUT_REDIRECT_URI=https://xxxxxxxxx.xxx/xxxx

--- a/simple-rp-simulator/front-end/dashboard.pug
+++ b/simple-rp-simulator/front-end/dashboard.pug
@@ -5,6 +5,7 @@ block content
 		h3 Welcome #{userInfo.displayName},
 		p.lead.mb-5 You have successfully authenticated with IBM Security Verify.
 		p Below is the information retrieved from the <code>userInfo</code> endpoint for the authenticated user.
+		p This is value from ID Token: #{JSON.stringify(tokenSet)}
 	.container
 		.row
 			.col-md-8


### PR DESCRIPTION
# Summary | Résumé

> POC back-channel logout on simple RP simulator
> this POC use *sub* as Session key, so when back-channel logout been called, can use *sub* to destroy session.
> *sub* or *sid* (session Id) can be used for session key, this demo use *sub*.
> [Github issue](https://github.com/cds-snc/gc-signin-oidc-rp-simulator/issues/25)
> [Zenhub issue](https://app.zenhub.com/workspaces/gc-sign-in-67227029924868000f954696/issues/gh/cds-snc/gc-signin-oidc-rp-simulator/25)

---


# Test instructions | Instructions pour tester la modification

> New feature : back-channel logout
> Step 1. need to set on GC Sign-in Admin->Application->Sign-On->Single Logout Settings 
> Step 2. env add POST_LOGOUT_REDIRECT_URI new config

