### PR TITLE
fix: Update OIDC apply role name in workflows

### DIFF
--- a/.github/workflows/rp-docker-build-push-ecr-dev.yml
+++ b/.github/workflows/rp-docker-build-push-ecr-dev.yml
@@ -39,7 +39,7 @@ jobs:
     - name: configure aws credentials using OIDC role
       uses: aws-actions/configure-aws-credentials@b47578312673ae6fa5b5096b330d9fbac3d116df # v4.2.1
       with:
-        role-to-assume: arn:aws:iam::${{ vars.DEV_AWS_ACCOUNT_ID }}:role/gc-signin-oidc-rp-simulator-apply
+        role-to-assume: arn:aws:iam::${{ vars.DEV_AWS_ACCOUNT_ID }}:role/canadalogin-oidc-rp-simulator-apply
         role-session-name: ECRPush 
         aws-region: ${{ env.AWS_REGION }}
 

--- a/.github/workflows/rp-docker-build-push-ecr-staging.yml
+++ b/.github/workflows/rp-docker-build-push-ecr-staging.yml
@@ -39,7 +39,7 @@ jobs:
     - name: configure aws credentials using OIDC role
       uses: aws-actions/configure-aws-credentials@b47578312673ae6fa5b5096b330d9fbac3d116df # v4.2.1
       with:
-        role-to-assume: arn:aws:iam::${{ vars.STAGING_AWS_ACCOUNT_ID }}:role/gc-signin-oidc-rp-simulator-apply
+        role-to-assume: arn:aws:iam::${{ vars.STAGING_AWS_ACCOUNT_ID }}:role/canadalogin-oidc-rp-simulator-apply
         role-session-name: ECRPush 
         aws-region: ${{ env.AWS_REGION }}
 

--- a/.github/workflows/rp-docker-build-push-ecr-test.yml
+++ b/.github/workflows/rp-docker-build-push-ecr-test.yml
@@ -39,7 +39,7 @@ jobs:
     - name: configure aws credentials using OIDC role
       uses: aws-actions/configure-aws-credentials@b47578312673ae6fa5b5096b330d9fbac3d116df # v4.2.1
       with:
-        role-to-assume: arn:aws:iam::${{ vars.TEST_AWS_ACCOUNT_ID }}:role/gc-signin-oidc-rp-simulator-apply
+        role-to-assume: arn:aws:iam::${{ vars.TEST_AWS_ACCOUNT_ID }}:role/canadalogin-oidc-rp-simulator-apply
         role-session-name: ECRPush 
         aws-region: ${{ env.AWS_REGION }}
 


### PR DESCRIPTION
# Summary | Résumé

This PR updates the OIDC apply roles now that we've renamed this repo and the role names have changes.

# Testing

I've validated that these roles exist in AWS:

<img width="314" height="84" alt="Screenshot 2026-06-05 at 10 30 19 AM" src="https://github.com/user-attachments/assets/de549368-0788-45c4-9f5d-1fb8f857a804" />
