### PR TITLE
fix: Update generate-sbom action pin

### DIFF
--- a/.github/workflows/rp-docker-build-push-ecr-dev.yml
+++ b/.github/workflows/rp-docker-build-push-ecr-dev.yml
@@ -60,7 +60,7 @@ jobs:
         docker push $ECR:latest
 
     - name: Docker generate SBOM
-      uses: cds-snc/security-tools/.github/actions/generate-sbom@34794baf2af592913bb5b51d8df4f8d0acc49b6f # v3.2.0
+      uses: cds-snc/security-tools/.github/actions/generate-sbom@12a0cdea1c5a515dfcbe353693db804a1793c0ed # v3.2.0
       env:
         TRIVY_DB_REPOSITORY: ${{ vars.TRIVY_DB_REPOSITORY }}
       with:

--- a/.github/workflows/rp-docker-build-push-ecr-dev.yml
+++ b/.github/workflows/rp-docker-build-push-ecr-dev.yml
@@ -60,7 +60,7 @@ jobs:
         docker push $ECR:latest
 
     - name: Docker generate SBOM
-      uses: cds-snc/security-tools/.github/actions/generate-sbom@12a0cdea1c5a515dfcbe353693db804a1793c0ed # v3.2.0
+      uses: cds-snc/security-tools/.github/actions/generate-sbom@12a0cdea1c5a515dfcbe353693db804a1793c0ed # v4.0.1
       env:
         TRIVY_DB_REPOSITORY: ${{ vars.TRIVY_DB_REPOSITORY }}
       with:

--- a/.github/workflows/rp-docker-build-push-ecr-staging.yml
+++ b/.github/workflows/rp-docker-build-push-ecr-staging.yml
@@ -60,7 +60,7 @@ jobs:
         docker push $ECR:latest
 
     - name: Docker generate SBOM
-      uses: cds-snc/security-tools/.github/actions/generate-sbom@12a0cdea1c5a515dfcbe353693db804a1793c0ed # v3.2.0
+      uses: cds-snc/security-tools/.github/actions/generate-sbom@12a0cdea1c5a515dfcbe353693db804a1793c0ed # v4.0.1
       env:
         TRIVY_DB_REPOSITORY: ${{ vars.TRIVY_DB_REPOSITORY }}
         TRIVY_VERSION: v0.56.2

--- a/.github/workflows/rp-docker-build-push-ecr-staging.yml
+++ b/.github/workflows/rp-docker-build-push-ecr-staging.yml
@@ -60,7 +60,7 @@ jobs:
         docker push $ECR:latest
 
     - name: Docker generate SBOM
-      uses: cds-snc/security-tools/.github/actions/generate-sbom@34794baf2af592913bb5b51d8df4f8d0acc49b6f # v3.2.0
+      uses: cds-snc/security-tools/.github/actions/generate-sbom@12a0cdea1c5a515dfcbe353693db804a1793c0ed # v3.2.0
       env:
         TRIVY_DB_REPOSITORY: ${{ vars.TRIVY_DB_REPOSITORY }}
         TRIVY_VERSION: v0.56.2

--- a/.github/workflows/rp-docker-build-push-ecr-test.yml
+++ b/.github/workflows/rp-docker-build-push-ecr-test.yml
@@ -60,7 +60,7 @@ jobs:
         docker push $ECR:latest
 
     - name: Docker generate SBOM
-      uses: cds-snc/security-tools/.github/actions/generate-sbom@34794baf2af592913bb5b51d8df4f8d0acc49b6f # v3.2.0
+      uses: cds-snc/security-tools/.github/actions/generate-sbom@12a0cdea1c5a515dfcbe353693db804a1793c0ed # v3.2.0
       env:
         TRIVY_DB_REPOSITORY: ${{ vars.TRIVY_DB_REPOSITORY }}
       with:

--- a/.github/workflows/rp-docker-build-push-ecr-test.yml
+++ b/.github/workflows/rp-docker-build-push-ecr-test.yml
@@ -60,7 +60,7 @@ jobs:
         docker push $ECR:latest
 
     - name: Docker generate SBOM
-      uses: cds-snc/security-tools/.github/actions/generate-sbom@12a0cdea1c5a515dfcbe353693db804a1793c0ed # v3.2.0
+      uses: cds-snc/security-tools/.github/actions/generate-sbom@12a0cdea1c5a515dfcbe353693db804a1793c0ed # v4.0.1
       env:
         TRIVY_DB_REPOSITORY: ${{ vars.TRIVY_DB_REPOSITORY }}
       with:


### PR DESCRIPTION
# Summary | Résumé

This PR updates the generate-sbom GitHub action to resolve a trivy-related CI failure.
